### PR TITLE
Resolve Filename Error in GIS Data Download tab.

### DIFF
--- a/mastersheet/views.py
+++ b/mastersheet/views.py
@@ -1805,7 +1805,7 @@ def AnalyseGisTabData(slum_id):
 def gisDataDownload(request):
     slum_id = request.POST.get('slum_name')
     response_data,  columns_lst = AnalyseGisTabData(slum_id)
-    filename = slum_code[0][1]+'.csv'
+    filename = str(slum_id)+'.csv'
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition']  =  'attachment; filename='+filename
     writer = csv.DictWriter(response, columns_lst)


### PR DESCRIPTION
When we are going to download data using the GIS Data Download tab, due to unwanted punctuations present in the slum name we are getting an error. To Resolve this problem I have changed the slum name to slum id in filename creation.