### PR TITLE
Resolving the issue "Slum name is not included when downloading excel file from Summary tab."

### DIFF
--- a/static/js/load_datatable.js
+++ b/static/js/load_datatable.js
@@ -759,7 +759,7 @@ $(document).ready(function () {
                 "buttons": btn_default,
                 "columnDefs": [{ "defaultContent": "-", "targets": "_all" }, { "footer": true }, { "targets": 0, "visible": false, "searchable": false }],
                 "columns": [
-                    { 'data': 'slum_name', 'title': 'Slum' },
+                    { 'data': 'slum', 'title': 'Slum' },
                     { 'data': 'household_number', 'title': 'Household Number' },
                     { 'data': 'pluscodes', 'title': 'Plus Code' },
                     { 'data': 'occupancy_status', 'title': 'Occupancy Status' },


### PR DESCRIPTION
When the user downloads data from the summary tab then the slum name is not included with the data. I fix this issue.